### PR TITLE
small fix on a naming issue

### DIFF
--- a/sigkernel/static_kernels.py
+++ b/sigkernel/static_kernels.py
@@ -116,7 +116,7 @@ class RBF_CEXP_Kernel(RBFKernel):
 class RBF_SQR_Kernel():
     """RBF SQR kernel k: H x H -> R"""
 
-    def __init__(self, sigma1, sigma2):
+    def __init__(self, sigma_1, sigma_2):
         self.rbf1 = RBFKernel(sigma_1)
         self.rbf2 = RBFKernel(sigma_2)
 


### PR DESCRIPTION
Thanks for sharing your code! I've noticed a small naming issue as I was experimenting with it, and I fixed it. 
Namely, it some `sigma1, sigma2` parameters in the `static_kernels.py` file that were meant to be `sigma_1` and `sigma_2`.