### PR TITLE
Create pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "Cython>=0.29.21"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This pull request adds a pyproject.toml file to the root of the repository to address build issues related to PEP 517 build isolation. Previously, installing the package would fail because Cython wasn’t available in the isolated build environment, even though it was installed in the virtual environment. By declaring the required build dependencies (setuptools, wheel, and Cython) explicitly, this change ensures a consistent and reliable build process across different environments.