### PR TITLE
Add Apple Silicon MPS backend support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,5 @@ __pycache__/
 /.idea
 /build
 /venv
+*.so
+sigkernel/cython_backend.c

--- a/examples/time_series_classification.py
+++ b/examples/time_series_classification.py
@@ -167,11 +167,15 @@ if __name__ == '__main__':
                 #==================================================================================
                 # Signature PDE kernel
                 #==================================================================================
-                # move to cuda (if available and memory doesn't exceed a certain threshold)
                 if x_train.shape[0] <= 150 and x_train.shape[1] <=150 and x_train.shape[2] <= 8:
-                    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+                    if torch.cuda.is_available():
+                        device = torch.device('cuda')
+                    elif torch.backends.mps.is_available():
+                        device = torch.device('mps')
+                    else:
+                        device = torch.device('cpu')
                     dtype = torch.float32
-                else: # otherwise do computations in cython
+                else:
                     device = 'cpu'
                     dtype = torch.float64
                 

--- a/sigkernel/__init__.py
+++ b/sigkernel/__init__.py
@@ -1,3 +1,4 @@
 from .transformers import *
 from .cuda_backend import *
+from .mps_backend import *
 from .sigkernel import *

--- a/sigkernel/mps_backend.py
+++ b/sigkernel/mps_backend.py
@@ -1,0 +1,129 @@
+import torch
+
+def _get_diagonal_indices(diagonal_idx, len_x, len_y, device):
+    """Extract (i,j) index pairs for all grid points on specified anti-diagonal.
+
+    Input:
+        - diagonal_idx: int, diagonal index from 0 to 2*max(len_x,len_y)-2
+        - len_x: int, first path dimension
+        - len_y: int, second path dimension
+        - device: torch device for index tensors
+    Output:
+        - i_indices: 1D tensor of i coordinates
+        - j_indices: 1D tensor of j coordinates
+    """
+    max_i = min(diagonal_idx, len_x - 1)
+    min_i = max(0, diagonal_idx - (len_y - 1))
+
+    i_indices = torch.arange(min_i, max_i + 1, device=device, dtype=torch.long)
+    j_indices = diagonal_idx - i_indices
+
+    return i_indices, j_indices
+
+
+def sigkernel_mps(M_inc, len_x, len_y, M_sol, _naive_solver=False):
+    """Signature kernel PDE solver for MPS backend using vectorized anti-diagonal sweep.
+
+    Input:
+        - M_inc: torch tensor of shape (batch, len_x, len_y), PDE increments
+        - len_x: int, first path length
+        - len_y: int, second path length
+        - M_sol: torch tensor of shape (batch, len_x+2, len_y+2), solution matrix (modified in-place)
+        - _naive_solver: bool, if True use first-order solver, else higher-order Padé
+    """
+    n_anti_diagonals = len_x + len_y - 1
+    device = M_inc.device
+
+    for p in range(n_anti_diagonals):
+        i_idx, j_idx = _get_diagonal_indices(p, len_x, len_y, device)
+
+        inc = M_inc[:, i_idx, j_idx]
+
+        k_01 = M_sol[:, i_idx, j_idx + 1]
+        k_10 = M_sol[:, i_idx + 1, j_idx]
+        k_00 = M_sol[:, i_idx, j_idx]
+
+        if _naive_solver:
+            M_sol[:, i_idx + 1, j_idx + 1] = (k_01 + k_10) * (1. + 0.5 * inc) - k_00
+        else:
+            M_sol[:, i_idx + 1, j_idx + 1] = (k_01 + k_10) * (1. + 0.5 * inc + (1./12) * inc**2) - k_00 * (1. - (1./12) * inc**2)
+
+
+def sigkernel_Gram_mps(M_inc, len_x, len_y, M_sol, _naive_solver=False):
+    """Signature kernel Gram matrix PDE solver for MPS backend using vectorized anti-diagonal sweep.
+
+    Input:
+        - M_inc: torch tensor of shape (batch_X, batch_Y, len_x, len_y), PDE increments
+        - len_x: int, first path length
+        - len_y: int, second path length
+        - M_sol: torch tensor of shape (batch_X, batch_Y, len_x+2, len_y+2), solution matrix (modified in-place)
+        - _naive_solver: bool, if True use first-order solver, else higher-order Padé
+    """
+    n_anti_diagonals = len_x + len_y - 1
+    device = M_inc.device
+
+    for p in range(n_anti_diagonals):
+        i_idx, j_idx = _get_diagonal_indices(p, len_x, len_y, device)
+
+        inc = M_inc[:, :, i_idx, j_idx]
+
+        k_01 = M_sol[:, :, i_idx, j_idx + 1]
+        k_10 = M_sol[:, :, i_idx + 1, j_idx]
+        k_00 = M_sol[:, :, i_idx, j_idx]
+
+        if _naive_solver:
+            M_sol[:, :, i_idx + 1, j_idx + 1] = (k_01 + k_10) * (1. + 0.5 * inc) - k_00
+        else:
+            M_sol[:, :, i_idx + 1, j_idx + 1] = (k_01 + k_10) * (1. + 0.5 * inc + (1./12) * inc**2) - k_00 * (1. - (1./12) * inc**2)
+
+
+def sigkernel_derivatives_Gram_mps(M_inc, M_inc_diff, M_inc_diffdiff, len_x, len_y, M_sol, M_sol_diff, M_sol_diffdiff):
+    """Signature kernel derivatives PDE solver for MPS backend using vectorized anti-diagonal sweep.
+
+    Computes kernel and its first/second directional derivatives simultaneously.
+
+    Input:
+        - M_inc: torch tensor of shape (batch_X, batch_Y, len_x, len_y), PDE increments
+        - M_inc_diff: torch tensor of shape (batch_X, batch_Y, len_x, len_y), first derivative increments
+        - M_inc_diffdiff: torch tensor of shape (batch_X, batch_Y, len_x, len_y), second derivative increments
+        - len_x: int, first path length
+        - len_y: int, second path length
+        - M_sol: torch tensor of shape (batch_X, batch_Y, len_x+2, len_y+2), kernel solution (modified in-place)
+        - M_sol_diff: torch tensor of shape (batch_X, batch_Y, len_x+2, len_y+2), first derivative solution (modified in-place)
+        - M_sol_diffdiff: torch tensor of shape (batch_X, batch_Y, len_x+2, len_y+2), second derivative solution (modified in-place)
+    """
+    n_anti_diagonals = len_x + len_y - 1
+    device = M_inc.device
+
+    for p in range(n_anti_diagonals):
+        i_idx, j_idx = _get_diagonal_indices(p, len_x, len_y, device)
+
+        inc = M_inc[:, :, i_idx, j_idx]
+        inc_diff = M_inc_diff[:, :, i_idx, j_idx]
+        inc_diffdiff = M_inc_diffdiff[:, :, i_idx, j_idx]
+
+        k_01 = M_sol[:, :, i_idx, j_idx + 1]
+        k_10 = M_sol[:, :, i_idx + 1, j_idx]
+        k_00 = M_sol[:, :, i_idx, j_idx]
+
+        k_01_diff = M_sol_diff[:, :, i_idx, j_idx + 1]
+        k_10_diff = M_sol_diff[:, :, i_idx + 1, j_idx]
+        k_00_diff = M_sol_diff[:, :, i_idx, j_idx]
+
+        k_01_diffdiff = M_sol_diffdiff[:, :, i_idx, j_idx + 1]
+        k_10_diffdiff = M_sol_diffdiff[:, :, i_idx + 1, j_idx]
+        k_00_diffdiff = M_sol_diffdiff[:, :, i_idx, j_idx]
+
+        M_sol[:, :, i_idx + 1, j_idx + 1] = (k_01 + k_10) * (1. + 0.5 * inc + (1./12) * inc**2) - k_00 * (1. - (1./12) * inc**2)
+
+        f1 = k_00 * inc_diff + k_00_diff * inc
+        f2 = k_01 * inc_diff + k_01_diff * inc
+        f3 = k_10 * inc_diff + k_10_diff * inc
+        f4 = M_sol[:, :, i_idx + 1, j_idx + 1] * inc_diff + (k_01_diff + k_10_diff - k_00_diff + f1) * inc
+        M_sol_diff[:, :, i_idx + 1, j_idx + 1] = k_01_diff + k_10_diff - k_00_diff + 0.25 * (f1 + f2 + f3 + f4)
+
+        g1 = k_00 * inc_diffdiff + 2. * k_00_diff * inc_diff + k_00_diffdiff * inc
+        g2 = k_01 * inc_diffdiff + 2. * k_01_diff * inc_diff + k_01_diffdiff * inc
+        g3 = k_10 * inc_diffdiff + 2. * k_10_diff * inc_diff + k_10_diffdiff * inc
+        g4 = M_sol[:, :, i_idx + 1, j_idx + 1] * inc_diffdiff + 2. * M_sol_diff[:, :, i_idx + 1, j_idx + 1] * inc_diff + (k_01_diffdiff + k_10_diffdiff - k_00_diffdiff + g1) * inc
+        M_sol_diffdiff[:, :, i_idx + 1, j_idx + 1] = k_01_diffdiff + k_10_diffdiff - k_00_diffdiff + 0.25 * (g1 + g2 + g3 + g4)

--- a/sigkernel/test_mps.py
+++ b/sigkernel/test_mps.py
@@ -1,0 +1,262 @@
+import torch
+import sigkernel
+
+
+def test_mps_availability():
+    """Test that MPS is available on this system."""
+    if not torch.backends.mps.is_available():
+        print("SKIP: MPS not available on this system")
+        return False
+    print("✓ MPS is available")
+    return True
+
+
+def test_basic_kernel():
+    """Test basic batch kernel computation: MPS vs CPU."""
+    print("\nTesting basic kernel computation...")
+
+    X_cpu = torch.randn(3, 8, 2, dtype=torch.float32)
+    Y_cpu = torch.randn(3, 10, 2, dtype=torch.float32)
+
+    X_mps = X_cpu.to('mps')
+    Y_mps = Y_cpu.to('mps')
+
+    static_kernel = sigkernel.RBFKernel(sigma=1.0)
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=0)
+
+    K_cpu = sig_kernel.compute_kernel(X_cpu, Y_cpu)
+    K_mps = sig_kernel.compute_kernel(X_mps, Y_mps)
+
+    K_mps_on_cpu = K_mps.cpu()
+
+    if torch.allclose(K_mps_on_cpu, K_cpu, rtol=1e-4, atol=1e-5):
+        print(f"✓ Basic kernel: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e}")
+        return True
+    else:
+        print(f"✗ Basic kernel: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e} (FAILED)")
+        return False
+
+
+def test_gram_matrix():
+    """Test Gram matrix computation: MPS vs CPU."""
+    print("\nTesting Gram matrix computation...")
+
+    X_cpu = torch.randn(4, 6, 2, dtype=torch.float32)
+    Y_cpu = torch.randn(5, 6, 2, dtype=torch.float32)
+
+    X_mps = X_cpu.to('mps')
+    Y_mps = Y_cpu.to('mps')
+
+    static_kernel = sigkernel.RBFKernel(sigma=0.5)
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=0)
+
+    G_cpu = sig_kernel.compute_Gram(X_cpu, Y_cpu, sym=False)
+    G_mps = sig_kernel.compute_Gram(X_mps, Y_mps, sym=False)
+
+    G_mps_on_cpu = G_mps.cpu()
+
+    if torch.allclose(G_mps_on_cpu, G_cpu, rtol=1e-4, atol=1e-5):
+        print(f"✓ Gram matrix: max diff = {torch.max(torch.abs(G_mps_on_cpu - G_cpu)).item():.2e}")
+        return True
+    else:
+        print(f"✗ Gram matrix: max diff = {torch.max(torch.abs(G_mps_on_cpu - G_cpu)).item():.2e} (FAILED)")
+        return False
+
+
+def test_symmetric_gram():
+    """Test symmetric Gram matrix computation: MPS vs CPU."""
+    print("\nTesting symmetric Gram matrix...")
+
+    X_cpu = torch.randn(5, 8, 2, dtype=torch.float32)
+
+    X_mps = X_cpu.to('mps')
+
+    static_kernel = sigkernel.RBFKernel(sigma=1.0)
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=0)
+
+    G_cpu = sig_kernel.compute_Gram(X_cpu, X_cpu, sym=True)
+    G_mps = sig_kernel.compute_Gram(X_mps, X_mps, sym=True)
+
+    G_mps_on_cpu = G_mps.cpu()
+
+    if torch.allclose(G_mps_on_cpu, G_cpu, rtol=1e-4, atol=1e-5):
+        print(f"✓ Symmetric Gram: max diff = {torch.max(torch.abs(G_mps_on_cpu - G_cpu)).item():.2e}")
+        return True
+    else:
+        print(f"✗ Symmetric Gram: max diff = {torch.max(torch.abs(G_mps_on_cpu - G_cpu)).item():.2e} (FAILED)")
+        return False
+
+
+def test_gradients():
+    """Test gradient computation via backward pass: MPS."""
+    print("\nTesting gradient computation...")
+
+    X_mps = torch.randn(3, 6, 2, device='mps', dtype=torch.float32, requires_grad=True)
+    Y_mps = torch.randn(3, 6, 2, device='mps', dtype=torch.float32)
+
+    static_kernel = sigkernel.RBFKernel(sigma=0.5)
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=0)
+
+    K = sig_kernel.compute_kernel(X_mps, Y_mps)
+    loss = K.sum()
+    loss.backward()
+
+    if X_mps.grad is not None and torch.isfinite(X_mps.grad).all():
+        print(f"✓ Gradients: grad norm = {torch.norm(X_mps.grad).item():.2e}")
+        return True
+    else:
+        print("✗ Gradients: contains NaN or inf (FAILED)")
+        return False
+
+
+def test_dyadic_order():
+    """Test with different dyadic orders: MPS vs CPU."""
+    print("\nTesting dyadic_order=1...")
+
+    X_cpu = torch.randn(2, 5, 2, dtype=torch.float32)
+    Y_cpu = torch.randn(2, 5, 2, dtype=torch.float32)
+
+    X_mps = X_cpu.to('mps')
+    Y_mps = Y_cpu.to('mps')
+
+    static_kernel = sigkernel.RBFKernel(sigma=1.0)
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=1)
+
+    K_cpu = sig_kernel.compute_kernel(X_cpu, Y_cpu)
+    K_mps = sig_kernel.compute_kernel(X_mps, Y_mps)
+
+    K_mps_on_cpu = K_mps.cpu()
+
+    if torch.allclose(K_mps_on_cpu, K_cpu, rtol=1e-4, atol=1e-5):
+        print(f"✓ Dyadic order 1: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e}")
+        return True
+    else:
+        print(f"✗ Dyadic order 1: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e} (FAILED)")
+        return False
+
+
+def test_mmd():
+    """Test MMD computation: MPS vs CPU."""
+    print("\nTesting MMD computation...")
+
+    X_cpu = torch.randn(6, 8, 2, dtype=torch.float32)
+    Y_cpu = torch.randn(6, 8, 2, dtype=torch.float32)
+
+    X_mps = X_cpu.to('mps')
+    Y_mps = Y_cpu.to('mps')
+
+    static_kernel = sigkernel.RBFKernel(sigma=0.5)
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=0)
+
+    mmd_cpu = sig_kernel.compute_mmd(X_cpu, Y_cpu)
+    mmd_mps = sig_kernel.compute_mmd(X_mps, Y_mps)
+
+    mmd_mps_val = mmd_mps.cpu().item()
+    mmd_cpu_val = mmd_cpu.item()
+
+    if abs(mmd_mps_val - mmd_cpu_val) < 1e-4:
+        print(f"✓ MMD: diff = {abs(mmd_mps_val - mmd_cpu_val):.2e}")
+        return True
+    else:
+        print(f"✗ MMD: diff = {abs(mmd_mps_val - mmd_cpu_val):.2e} (FAILED)")
+        return False
+
+
+def test_linear_kernel():
+    """Test with LinearKernel: MPS vs CPU."""
+    print("\nTesting with LinearKernel...")
+
+    X_cpu = torch.randn(3, 6, 2, dtype=torch.float32)
+    Y_cpu = torch.randn(3, 6, 2, dtype=torch.float32)
+
+    X_mps = X_cpu.to('mps')
+    Y_mps = Y_cpu.to('mps')
+
+    static_kernel = sigkernel.LinearKernel()
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=0)
+
+    K_cpu = sig_kernel.compute_kernel(X_cpu, Y_cpu)
+    K_mps = sig_kernel.compute_kernel(X_mps, Y_mps)
+
+    K_mps_on_cpu = K_mps.cpu()
+
+    if torch.allclose(K_mps_on_cpu, K_cpu, rtol=1e-4, atol=1e-5):
+        print(f"✓ LinearKernel: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e}")
+        return True
+    else:
+        print(f"✗ LinearKernel: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e} (FAILED)")
+        return False
+
+
+def test_asymmetric_paths():
+    """Test with different path lengths: MPS vs CPU."""
+    print("\nTesting asymmetric path lengths...")
+
+    X_cpu = torch.randn(2, 10, 2, dtype=torch.float32)
+    Y_cpu = torch.randn(2, 15, 2, dtype=torch.float32)
+
+    X_mps = X_cpu.to('mps')
+    Y_mps = Y_cpu.to('mps')
+
+    static_kernel = sigkernel.RBFKernel(sigma=1.0)
+    sig_kernel = sigkernel.SigKernel(static_kernel, dyadic_order=0)
+
+    K_cpu = sig_kernel.compute_kernel(X_cpu, Y_cpu)
+    K_mps = sig_kernel.compute_kernel(X_mps, Y_mps)
+
+    K_mps_on_cpu = K_mps.cpu()
+
+    if torch.allclose(K_mps_on_cpu, K_cpu, rtol=1e-4, atol=1e-5):
+        print(f"✓ Asymmetric paths: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e}")
+        return True
+    else:
+        print(f"✗ Asymmetric paths: max diff = {torch.max(torch.abs(K_mps_on_cpu - K_cpu)).item():.2e} (FAILED)")
+        return False
+
+
+def run_all_tests():
+    """Run all MPS tests."""
+    print("=" * 60)
+    print("MPS Backend Test Suite for sigkernel")
+    print("=" * 60)
+
+    if not test_mps_availability():
+        print("\nTests skipped: MPS not available")
+        return
+
+    tests = [
+        test_basic_kernel,
+        test_gram_matrix,
+        test_symmetric_gram,
+        test_gradients,
+        test_dyadic_order,
+        test_mmd,
+        test_linear_kernel,
+        test_asymmetric_paths,
+    ]
+
+    passed = 0
+    failed = 0
+
+    for test in tests:
+        try:
+            if test():
+                passed += 1
+            else:
+                failed += 1
+        except Exception as e:
+            print(f"✗ {test.__name__}: Exception - {str(e)}")
+            failed += 1
+
+    print("\n" + "=" * 60)
+    print(f"Results: {passed} passed, {failed} failed")
+    print("=" * 60)
+
+    if failed == 0:
+        print("✓ All tests passed!")
+    else:
+        print(f"✗ {failed} test(s) failed")
+
+
+if __name__ == "__main__":
+    run_all_tests()


### PR DESCRIPTION
Hello maintainers -- Thank you for building this project. I added Apple Silicon GPU support to take advantage of the GPUs in Apple MacBook Pros for use-cases where one can avoid buying or renting Nvidia GPUs. Sharing in case you want to add it to the project.

---

Implements GPU acceleration for Apple Silicon (M1/M2/M3) Macs via PyTorch's Metal Performance Shaders (MPS) backend.

Features:
- New mps_backend.py with vectorized anti-diagonal PDE solver
- Three-way device dispatch: CUDA > MPS > CPU
- Full feature parity: kernel, Gram matrix, derivatives, MMD
- Test suite (test_mps.py)
- Updated docs w/ examples

Implementation uses pure PyTorch operations for MPS compatibility, with equivalent numerical accuracy to existing CUDA/CPU backends.

Requires PyTorch >= 1.12 for MPS support.